### PR TITLE
Update terms_and_conditions.rst

### DIFF
--- a/sales/send_quotations/terms_and_conditions.rst
+++ b/sales/send_quotations/terms_and_conditions.rst
@@ -14,7 +14,7 @@ quotation, sales order and invoice.
 Set up your default terms and conditions
 ========================================
 
-Go to :menuselection:`SALES --> Configuration --> Settings` and activate
+Go to :menuselection:`Accounting --> Configuration --> Settings` and activate
 *Default Terms & Conditions*.
 
 .. image:: media/terms_and_conditions01.png 


### PR DESCRIPTION
Change **Go to SALES ‣ Configuration ‣ Settings and activate Default Terms & Conditions.** to **Go to Accounting ‣ Settings and activate Default Terms & Conditions** This is due to the fact that in V13 the Default Terms & Conditions setting is no longer available in under Sales but rather Accounting in the General Settings as well.